### PR TITLE
Add create route location mutation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,7 @@ ruby '2.7.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.2'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
+
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
@@ -32,12 +31,15 @@ gem 'graphql', '~> 1.11', '>= 1.11.1'
 
 gem 'sprockets', '~> 3'
 
-gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
+
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  # Use sqlite3 as the database for Active Record
+  gem 'sqlite3', '~> 1.4'
   gem 'graphiql-rails', '~> 1.7'
+  gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
 end
 
 group :development do
@@ -46,3 +48,7 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+group :production do
+  gem 'pg'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   # Use sqlite3 as the database for Active Record
-  gem 'sqlite3', '~> 1.4'
+  gem 'pg'
   gem 'graphiql-rails', '~> 1.7'
   gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    pg (1.2.3)
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.3)
@@ -144,7 +145,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
     tzinfo (1.2.7)
@@ -165,11 +165,11 @@ DEPENDENCIES
   graphql (~> 1.11, >= 1.11.1)
   jwt (~> 2.2, >= 2.2.1)
   listen (~> 3.2)
+  pg
   puma (~> 4.1)
   rack-cors (~> 1.1, >= 1.1.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   sprockets (~> 3)
-  sqlite3 (~> 1.4)
   tzinfo-data
 
 RUBY VERSION

--- a/app/controllers/api/v2/graphql_controller.rb
+++ b/app/controllers/api/v2/graphql_controller.rb
@@ -1,4 +1,4 @@
-
+module Api::V2
   class GraphqlController < ApplicationController
     # If accessing from outside this domain, nullify the session
     # This allows for outside API access while preventing CSRF attacks,
@@ -47,3 +47,4 @@
       render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: 500
     end
   end
+end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,4 +1,4 @@
-module Api::V2
+
   class GraphqlController < ApplicationController
     # If accessing from outside this domain, nullify the session
     # This allows for outside API access while preventing CSRF attacks,
@@ -47,4 +47,3 @@ module Api::V2
       render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: 500
     end
   end
-end

--- a/app/graphql/mutations/create_route.rb
+++ b/app/graphql/mutations/create_route.rb
@@ -4,6 +4,7 @@ module Mutations
 
     argument :name, String, required: true
     argument :description, String, required: true
+    argument :location_id, Integer, required: false
 
     def resolve(name:, description:)
       route = Route.create!(name: name, description: description)

--- a/app/graphql/mutations/create_route_location.rb
+++ b/app/graphql/mutations/create_route_location.rb
@@ -1,23 +1,23 @@
 module Mutations
   class CreateRouteLocation < BaseMutation
 
-    field :route_location, Types::RouteLocationType, null: false
+    field :route_location, Types::RouteLocationType, null: true
     field :errors, [String], null: false
 
-    argument :location_id, Types::LocationType, Integer, required: true
-    argument :route_id, Types::RouteType, Integer, required: true
+    argument :location_id, ID, required: true
+    argument :route_id, ID, required: true
 
-    def resolve(route_id:, location_id:, route_location:)
-      routeLocation = RouteLocation.save(route_id: route_id, location_id: location_id)
-      if RouteLocation.save
+    def resolve(route_id:, location_id:)
+      route_location = RouteLocation.new(route_id: route_id, location_id: location_id)
+      if route_location.save!
         {
-          routeLocation: routeLocation,
+          route_location: route_location,
           errors: []
         }
       else
         {
-          routeLocation: nil,
-          errors: routeLocation.errors.full_messages
+          route_location: nil,
+          errors: route_location.errors.full_messages
         }
       end
     end

--- a/app/graphql/mutations/create_route_location.rb
+++ b/app/graphql/mutations/create_route_location.rb
@@ -23,3 +23,4 @@ module Mutations
     end
   end
 end
+

--- a/app/graphql/mutations/create_route_location.rb
+++ b/app/graphql/mutations/create_route_location.rb
@@ -1,0 +1,25 @@
+module Mutations
+  class CreateRouteLocation < BaseMutation
+
+    field :route_location, Types::RouteLocationType, null: false
+    field :errors, [String], null: false
+
+    argument :location_id, Types::LocationType, Integer, required: true
+    argument :route_id, Types::RouteType, Integer, required: true
+
+    def resolve(route_id:, location_id:, route_location:)
+      routeLocation = RouteLocation.save(route_id: route_id, location_id: location_id)
+      if RouteLocation.save
+        {
+          routeLocation: routeLocation,
+          errors: []
+        }
+      else
+        {
+          routeLocation: nil,
+          errors: routeLocation.errors.full_messages
+        }
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/delete_route_location.rb
+++ b/app/graphql/mutations/delete_route_location.rb
@@ -1,0 +1,17 @@
+module Mutations
+  class DeleteRouteLocation < BaseMutation
+    graphql_name 'DeleteRouteLocation'
+
+    field :Routelocation, Types::RouteLocationType, null: true
+
+    argument :id, ID, required: true
+
+    def resolve(**args)
+      route_location = RouteLocation.find(args[:id])
+      route_location.destroy
+      {
+        route_location: route_location,
+      }
+    end
+  end
+end

--- a/app/graphql/mutations/delete_route_location.rb
+++ b/app/graphql/mutations/delete_route_location.rb
@@ -2,7 +2,7 @@ module Mutations
   class DeleteRouteLocation < BaseMutation
     graphql_name 'DeleteRouteLocation'
 
-    field :Routelocation, Types::RouteLocationType, null: true
+    field :RouteLocation, Types::RouteLocationType, null: true
 
     argument :id, ID, required: true
 

--- a/app/graphql/mutations/delete_route_location_by_ids.rb
+++ b/app/graphql/mutations/delete_route_location_by_ids.rb
@@ -1,0 +1,19 @@
+module Mutations
+  class DeleteRouteLocationByIds < BaseMutation
+    graphql_name 'DeleteRouteLocationByIds'
+
+    field :routeLocation, Types::RouteLocationType, null: true
+
+    argument :location_id, Integer, required: true
+    argument :route_id, Integer, required:true
+
+    def resolve(location_id:, route_id:)
+      route_location_id = RouteLocation.where(location_id: location_id, route_id: route_id).ids.first
+      route_location = RouteLocation.find(route_location_id)
+      route_location.destroy
+      {
+        route_location: route_location
+      }
+    end
+  end
+end

--- a/app/graphql/mutations/delete_route_location_by_ids.rb
+++ b/app/graphql/mutations/delete_route_location_by_ids.rb
@@ -4,8 +4,8 @@ module Mutations
 
     field :routeLocation, Types::RouteLocationType, null: true
 
-    argument :location_id, Integer, required: true
-    argument :route_id, Integer, required:true
+    argument :location_id, ID, required: true
+    argument :route_id, ID, required:true
 
     def resolve(location_id:, route_id:)
       route_location_id = RouteLocation.where(location_id: location_id, route_id: route_id).ids.first

--- a/app/graphql/tipping_point_api_schema.rb
+++ b/app/graphql/tipping_point_api_schema.rb
@@ -3,9 +3,9 @@ class TippingPointApiSchema < GraphQL::Schema
   query(Types::QueryType)
 
   # Opt in to the new runtime (default in future graphql-ruby versions)
-  use GraphQL::Execution::Interpreter
-  use GraphQL::Analysis::AST
+  # use GraphQL::Execution::Interpreter
+  # use GraphQL::Analysis::AST
 
-  # Add built-in connections for pagination
-  use GraphQL::Pagination::Connections
+  # # Add built-in connections for pagination
+  # use GraphQL::Pagination::Connections
 end

--- a/app/graphql/types/location_type.rb
+++ b/app/graphql/types/location_type.rb
@@ -5,5 +5,6 @@ module Types
     field :routes, [Types::RouteType], null: true
     field :slug, String, null: false
     field :gps, String, null: false
+
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,6 +5,7 @@ module Types
     field :create_route, mutation: Mutations::CreateRoute
     field :delete_location, mutation: Mutations::DeleteLocation
     field :update_location, mutation: Mutations::UpdateLocation
+    field :create_route_location, mutation: Mutations::CreateRouteLocation
 
     field :create_location, mutation: Mutations::CreateLocation
     field(:create_location, {mutation: Mutations::CreateLocation})

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -6,6 +6,7 @@ module Types
     field :delete_location, mutation: Mutations::DeleteLocation
     field :update_location, mutation: Mutations::UpdateLocation
     field :create_route_location, mutation: Mutations::CreateRouteLocation
+    field :delete_route_location, mutation: Mutations::DeleteRouteLocation
 
     field :create_location, mutation: Mutations::CreateLocation
     field(:create_location, {mutation: Mutations::CreateLocation})

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -7,6 +7,7 @@ module Types
     field :update_location, mutation: Mutations::UpdateLocation
     field :create_route_location, mutation: Mutations::CreateRouteLocation
     field :delete_route_location, mutation: Mutations::DeleteRouteLocation
+    field :delete_route_location_by_Ids, mutation: Mutations::DeleteRouteLocationByIds
 
     field :create_location, mutation: Mutations::CreateLocation
     field(:create_location, {mutation: Mutations::CreateLocation})

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -45,5 +45,9 @@ module Types
       argument :id, ID, required: true
     end
 
+    def route_location(id:)
+      RouteLocation.find(id)
+    end
+
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -35,6 +35,15 @@ module Types
     end
 
     #route_locations
+    field :route_locations, Types::RouteLocationType, null: false
+
+    def route_locations
+      Route_Locations.all
+    end
+
+    field :route_location, Types::RouteLocationType, null: false do
+      argument :id, ID, required: true
+    end
 
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -35,10 +35,10 @@ module Types
     end
 
     #route_locations
-    field :route_locations, Types::RouteLocationType, null: false
+    field :route_locations, [Types::RouteLocationType], null: false
 
     def route_locations
-      Route_Locations.all
+      RouteLocation.all
     end
 
     field :route_location, Types::RouteLocationType, null: false do

--- a/app/graphql/types/route_location_type.rb
+++ b/app/graphql/types/route_location_type.rb
@@ -3,6 +3,8 @@ module Types
     field :id, ID, null: false
     field :route_id, Integer, null: false
     field :location_id, Integer, null: false
+    field :route, type:RouteType, null: false
+    field :locations, type:LocationType, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end

--- a/app/graphql/types/route_location_type.rb
+++ b/app/graphql/types/route_location_type.rb
@@ -1,8 +1,8 @@
 module Types
   class RouteLocationType < Types::BaseObject
     field :id, ID, null: false
-    field :route_id, Integer, null: false
-    field :location_id, Integer, null: false
+    field :route_id, ID, null: false
+    field :location_id, ID, null: false
     field :route, type:RouteType, null: false
     field :locations, type:LocationType, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/route_location_type.rb
+++ b/app/graphql/types/route_location_type.rb
@@ -1,8 +1,8 @@
 module Types
   class RouteLocationType < Types::BaseObject
     field :id, ID, null: false
-    field :route_id, Integer, null: true
-    field :location_id, Integer, null: true
+    field :route_id, Integer, null: false
+    field :location_id, Integer, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end

--- a/app/graphql/types/route_type.rb
+++ b/app/graphql/types/route_type.rb
@@ -5,6 +5,7 @@ module Types
     field :description, String, null: true
     field :locations, [Types::LocationType], null: true
     field :locations_count, Integer, null: true
+    field :route_locations, [Types::RouteLocationType], null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
     def locations_count

--- a/app/graphql/types/route_type.rb
+++ b/app/graphql/types/route_type.rb
@@ -8,7 +8,7 @@ module Types
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
     def locations_count
-      locations.size
+      object.locations.size
     end
   end
 end

--- a/app/models/route_location.rb
+++ b/app/models/route_location.rb
@@ -1,4 +1,5 @@
 class RouteLocation < ApplicationRecord
+  validates_presence_of location_id:, route_id:
   belongs_to :location
   belongs_to :route
 end

--- a/app/models/route_location.rb
+++ b/app/models/route_location.rb
@@ -1,5 +1,5 @@
 class RouteLocation < ApplicationRecord
-  validates_presence_of location_id:, route_id:
+  validates_presence_of :location_id, :route_id
   belongs_to :location
   belongs_to :route
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
@@ -21,5 +21,5 @@ test:
   database: db/test.sqlite3
 
 production:
-  <<: *default
-  database: db/production.sqlite3
+  adapter: postgresql
+  url: <%= ENV["DATABASE_URL"] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,21 +1,21 @@
 Rails.application.routes.draw do
 
-  post "/graphql", to: "graphql#execute"
-  if Rails.env.development?
-    mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
+  # post "/graphql", to: "graphql#execute"
+  # if Rails.env.development?
+  #   mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
 
-  end
-
-  # namespace :api do
-  #   namespace :v1 do
-  #     resources :locations
-  #   end
-  #   namespace :v2 do
-  #     post "/graphql", to: "graphql#execute"
-  #     if Rails.env.development?
-  #       mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/api/v2/graphql"
-
-  #     end
-  #   end
   # end
+
+  namespace :api do
+    namespace :v1 do
+      resources :locations
+    end
+    namespace :v2 do
+      post "/graphql", to: "graphql#execute"
+      if Rails.env.development?
+        mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/api/v2/graphql"
+
+      end
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,21 @@
 Rails.application.routes.draw do
 
-  namespace :api do
-    namespace :v1 do
-      resources :locations
-    end
-    namespace :v2 do
-      post "/graphql", to: "graphql#execute"
-      if Rails.env.development?
-        mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/api/v2/graphql"
+  post "/graphql", to: "graphql#execute"
+  if Rails.env.development?
+    mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
 
-      end
-    end
   end
+
+  # namespace :api do
+  #   namespace :v1 do
+  #     resources :locations
+  #   end
+  #   namespace :v2 do
+  #     post "/graphql", to: "graphql#execute"
+  #     if Rails.env.development?
+  #       mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/api/v2/graphql"
+
+  #     end
+  #   end
+  # end
 end


### PR DESCRIPTION
I'm bangin my head against the wall here....


graphiQL error:

{
  "errors": [
    {
      "message": "Field must have selections (field 'createRouteLocation' returns CreateRouteLocationPayload but has no selections. Did you mean 'createRouteLocation { ... }'?)",
      "locations": [
        {
          "line": 2,
          "column": 2
        }
      ],
      "path": [
        "mutation",
        "createRouteLocation"
      ],
      "extensions": {
        "code": "selectionMismatch",
        "nodeName": "field 'createRouteLocation'",
        "typeName": "CreateRouteLocationPayload"
      }
    },
    {
      "message": "Field 'route' doesn't exist on type 'Mutation'",
      "locations": [
        {
          "line": 6,
          "column": 3
        }
      ],
      "path": [
        "mutation",
        "route"
      ],
      "extensions": {
        "code": "undefinedField",
        "typeName": "Mutation",
        "fieldName": "route"
      }
    }
  ]
}